### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/mod_shoutbox/script.php
+++ b/mod_shoutbox/script.php
@@ -616,7 +616,7 @@ class Mod_ShoutboxInstallerScript
 		$this->manageSmilies();
 
 		// Get the swearwords from the file
-		$file = file_get_contents(JPATH_ROOT . '/modules/mod_shoutbox/swearWords.php', NULL, NULL, 249);
+		$file = file_get_contents(JPATH_ROOT . '/modules/mod_shoutbox/swearWords.php', null, null, 249);
 		$explode = explode("\n", $file); // Explode the contents of the file
 		$words = array_filter($explode); // Remove empty values from array
 		unset($words[0]);                // Unset the first array index which contains a space


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!